### PR TITLE
allow to load YAML configuration files on Windows

### DIFF
--- a/altsrc/yaml_file_loader.go
+++ b/altsrc/yaml_file_loader.go
@@ -78,6 +78,11 @@ func loadDataFrom(filePath string) ([]byte, error) {
 			return nil, fmt.Errorf("Cannot read from file: '%s' because it does not exist.", filePath)
 		}
 		return ioutil.ReadFile(filePath)
+	} else if runtime.GOOS == "windows" && strings.Contains(u.String(), "\\") {
+		if _, notFoundFileErr := os.Stat(filePath); notFoundFileErr != nil {
+			return nil, fmt.Errorf("Cannot read from file: '%s' because it does not exist.", filePath)
+		}
+		return ioutil.ReadFile(filePath)
 	} else {
 		return nil, fmt.Errorf("unable to determine how to load from path %s", filePath)
 	}


### PR DESCRIPTION
The funtion `loadDataFrom` does not take care of Windows users since any of the conditions met and it returns an error.

The change looks for the runtime where it's running and then if the filePath contains a `\`